### PR TITLE
Add role based admin checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+
+.idea

--- a/main.py
+++ b/main.py
@@ -14,12 +14,13 @@ transcribe_everything = False
 bot_managers = [396545298069061642]
 
 # Alternatively, you can also give an entire role control over the bot by putting its Role ID here.
+# If you do put a Role ID here, you will also need to enable the Server Members intent.
 admin_role = None
 
 intents = discord.Intents.default()
 intents.messages = True
 intents.message_content = True
-intents.members = True
+intents.members = admin_role != None
 client = discord.Client(command_prefix='!', intents=intents)
 tree = app_commands.CommandTree(client)
 

--- a/main.py
+++ b/main.py
@@ -13,11 +13,13 @@ transcribe_everything = False
 # Currently, these people just have the ability to sync the bot's command tree.
 bot_managers = [396545298069061642]
 
-
+# Bot admin role ID goes here
+adminRole = 0
 
 intents = discord.Intents.default()
 intents.messages = True
 intents.message_content = True
+intents.members = True
 client = discord.Client(command_prefix='!', intents=intents)
 tree = app_commands.CommandTree(client)
 
@@ -55,13 +57,36 @@ async def transcribe_message(message):
 		result = "*nothing*"
 	await msg.edit(content="**Audio Message Transcription:\n** ```" + result + "```")
 
+
+async def is_admin(input: discord.Interaction or discord.message) -> bool:
+	if type(input) is discord.Interaction:
+		user = input.user
+	else:
+		user = input.author
+
+	admin = input.guild.get_role(adminRole)
+
+	if admin is None:
+		if type(input) is discord.Interaction:
+			await input.response.send_message(content="No admin role assigned, please update the variable with the proper ID")
+		else:
+			await input.reply("No admin role assigned, please update the variable with the proper ID")
+
+		return False
+
+	if user in admin.members:
+		return True
+	else:
+		return False
+
+
 @client.event
 async def on_message(message):
 	# "message.flags.value >> 13" should be replacable with "message.flags.voice" when VM support comes to discord.py, I think.
 	if transcribe_everything and message.flags.value >> 13 and len(message.attachments) == 1:
 		await transcribe_message(message)
 
-	if message.content == "!synctree" and message.author.id in bot_managers:
+	if message.content == "!synctree" and await is_admin(message):
 		await tree.sync(guild=None)
 		await message.reply("Synced!")
 		return
@@ -80,7 +105,7 @@ async def open_source(interaction: discord.Interaction):
     
 @tree.command(name="synctree", description="Syncs the bot's command tree.")
 async def synctree(interaction: discord.Interaction):
-	if interaction.user.id not in bot_managers:
+	if not await is_admin(interaction):
 		await interaction.response.send_message(content="You are not a Bot Manager!")
 		return
 


### PR DESCRIPTION
Allows the user to specify a role ID and give all those in possession of the role bot admin privileges

NOTE: Requires the members intent to function